### PR TITLE
Update the deploy contract with Hardhat new version

### DIFF
--- a/build-on-mode/deploying-a-smart-contract/using-hardhat.md
+++ b/build-on-mode/deploying-a-smart-contract/using-hardhat.md
@@ -137,12 +137,14 @@ In the `scripts` directory, create a new file named `deploy.ts`:
 import { ethers } from "hardhat";
 
 async function main() {
-    const HelloWorld = await ethers.getContractFactory("HelloWorld");
     const gasPrice = ethers.utils.parseUnits('10', 'gwei'); // Adjust the '10' as needed
     const gasLimit = 500000; // Adjust this value based on your needs
-    const helloWorld = await HelloWorld.deploy({ gasPrice: gasPrice, gasLimit: gasLimit });
-    await helloWorld.deployed();
-    console.log("HelloWorld deployed to:", helloWorld.address);
+    const HelloWorld = await ethers.deployContract("HelloWorld", {
+      gasPrice: gasPrice,
+      gasLimit: gasLimit,
+    });
+    await HelloWorld.waitForDeployment();
+    console.log("HelloWorld deployed to:", HelloWorld.getAddress());
 }
 
 main()


### PR DESCRIPTION
Description:
This Pull Request includes the following changes to use the new deploy features of Hardhat v2.0.0^:
- The ``deployContract()`` function is used instead of the old ``getContractFactory()`` and ``deploy()`` functions.
- New ``getAddress()`` function is used instead of old ``address``.

WHY?
In Hardhat v2.0.0, a number of changes were made to the deploy process, including the ``deployContract`` and ``waitForDeployment`` functions. So the old code was not working, so I updated it with the new version.

If you need more information about Hardhat v2.0.0^ check this guides: https://hardhat.org/hardhat-runner/docs/guides/deploying
