### PR TITLE
Add API3 under Oracles section

### DIFF
--- a/tools/oracles.md
+++ b/tools/oracles.md
@@ -1,5 +1,17 @@
 # 🧙‍♂️ Oracles
 
+## [API3](https://api3.org/)
+
+The [API3 Market](https://market.api3.org/mode) provides access to 200+ price feeds on [Mode Mainnet](https://market.api3.org/mode) and [Testnet](https://market.api3.org/mode-sepolia-testnet). The price feeds operate as a native push oracle and can be activated instantly via the Market UI.
+
+The price feeds are delivered by an aggregate of [first-party oracles](https://docs.api3.org/explore/airnode/why-first-party-oracles.html) using signed data and support [OEV recapture](https://docs.api3.org/explore/introduction/oracle-extractable-value.html).
+
+Unlike traditional data feeds, reading [API3 price feeds](https://docs.api3.org/guides/dapis/) enables dApps to auction off the right to update the price feeds to searcher bots which facilitates more efficient liquidation processes for users and LPs of DeFi money markets. The OEV recaptured is returned to the dApp.
+
+Check out these guides on how to:
+- [Use dAPIs on the Market](https://docs.api3.org/guides/dapis/subscribing-to-dapis/)
+- [Read a dAPI](https://docs.api3.org/guides/dapis/read-a-dapi/)
+
 ## [Pyth](https://pyth.network/)
 
 Pyth is an oracle for real-time blockchain data such as price feeds and historical market data.


### PR DESCRIPTION
Added [API3](https://api3.org/) under `/tools/oracles.md`. API3 is building first-party data feeds on Mode.