### PR TITLE
Fix typo node-operators.md

### DIFF
--- a/other-docs/node-operators.md
+++ b/other-docs/node-operators.md
@@ -18,7 +18,7 @@ Optimism Fork (Holocene) will be activated on ​Mainnet​ on ​`Thu 09 Jan 20
 
 ### Snapshots
 
-Snapshots will help you save time while synching your node to Mode.&#x20;
+Snapshots will help you save time while syncing your node to Mode.&#x20;
 
 * Mainnet
 


### PR DESCRIPTION
I fixed a typo in the README.md file, changing 'synching' to 'syncing'.