### PR TITLE
fix(docs): clarify Node.js version requirement

### DIFF
--- a/ai-agents/tutorials/quickstart.md
+++ b/ai-agents/tutorials/quickstart.md
@@ -10,7 +10,7 @@ description: >-
 
 ### Prerequisites
 
-* [Node.js v20.12.2](https://nodejs.org/) or higher.
+* [Node.js >=20.12.2](https://nodejs.org/) and <21.   
 * [Turbo](https://turbo.build/).
 * [PNPM](https://pnpm.io/).
 


### PR DESCRIPTION
Updated the Node.js version prerequisite to specify that it must be >=20.12.2 and <21, ensuring clarity on supported versions.