### PR TITLE
Add Envio to Data Indexers

### DIFF
--- a/tools/data-indexers.md
+++ b/tools/data-indexers.md
@@ -1,5 +1,17 @@
 # 🗂️ Data Indexers
 
+## [Envio](https://envio.dev/?utm_source=mode&utm_medium=partner-docs)
+
+Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, and Mode is served by HyperSync, Envio's high-performance data engine that is up to 2000x faster than traditional RPC.
+
+Auto-generate an indexer from any verified contract with `pnpx envio init`, write event handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host. HyperIndex supports reorgs, real-time and historical data, historical backfills at 30,000+ events per second, and multichain data aggregation across EVM and non-EVM networks.
+
+The Mode HyperSync endpoint is `https://mode.hypersync.xyz`.
+
+Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=mode&utm_medium=partner-docs) or read the [documentation](https://docs.envio.dev/?utm_source=mode&utm_medium=partner-docs).
+
+---
+
 ## [Goldsky](https://goldsky.com/)
 
 Goldsky offers two core self-serve products that can be used independently or in conjunction to power your data stack. Subgraphs that have flexible indexing with typescript, with support for webhooks and more. Then also Mirror which lets you get live blockchain data directly into your database or message queues with a single yaml config.\

--- a/tools/data-indexers.md
+++ b/tools/data-indexers.md
@@ -2,7 +2,7 @@
 
 ## [Envio](https://envio.dev/?utm_source=mode&utm_medium=partner-docs)
 
-Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, and Mode is served by HyperSync, Envio's high-performance data engine that is up to 2000x faster than traditional RPC.
+Envio is the data layer for blockchain apps. It gives Mode developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, and Mode is served by HyperSync, Envio's high-performance data engine that is up to 2000x faster than traditional RPC.
 
 Auto-generate an indexer from any verified contract with `pnpx envio init`, write event handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host. HyperIndex supports reorgs, real-time and historical data, historical backfills at 30,000+ events per second, and multichain data aggregation across EVM and non-EVM networks.
 

--- a/tools/data-indexers.md
+++ b/tools/data-indexers.md
@@ -10,8 +10,6 @@ The Mode HyperSync endpoint is `https://mode.hypersync.xyz`.
 
 Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=mode&utm_medium=partner-docs) or read the [documentation](https://docs.envio.dev/?utm_source=mode&utm_medium=partner-docs).
 
-See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=mode&utm_medium=partner-docs).
-
 ---
 
 ## [Goldsky](https://goldsky.com/)

--- a/tools/data-indexers.md
+++ b/tools/data-indexers.md
@@ -10,6 +10,8 @@ The Mode HyperSync endpoint is `https://mode.hypersync.xyz`.
 
 Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=mode&utm_medium=partner-docs) or read the [documentation](https://docs.envio.dev/?utm_source=mode&utm_medium=partner-docs).
 
+See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=mode&utm_medium=partner-docs).
+
 ---
 
 ## [Goldsky](https://goldsky.com/)


### PR DESCRIPTION
This adds Envio to the Data Indexers page.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. HyperIndex natively supports indexing any EVM chain, and Mode is served by HyperSync, Envio's high-performance data engine.

The entry mirrors the existing provider sections on the page and includes the Mode HyperSync endpoint.

Links:
- Website: https://envio.dev/
- Docs: https://docs.envio.dev/